### PR TITLE
Fix a problem with creating the custom-dnsmasq.conf

### DIFF
--- a/wifi-to-eth-route.sh
+++ b/wifi-to-eth-route.sh
@@ -44,6 +44,7 @@ bind-interfaces\n\
 server=8.8.8.8\n\
 domain-needed\n\
 bogus-priv\n\
-dhcp-range=$dhcp_range_start,$dhcp_range_end,$dhcp_time" > /etc/dnsmasq.d/custom-dnsmasq.conf
+dhcp-range=$dhcp_range_start,$dhcp_range_end,$dhcp_time" > /tmp/custom-dnsmasq.conf
 
+sudo cp /tmp/custom-dnsmasq.conf /etc/dnsmasq.d/custom-dnsmasq.conf
 sudo systemctl start dnsmasq


### PR DESCRIPTION
If the /etc/dnsmasq.d directory isn't writeable by the pi user, then it won't allow the custom conf to be created.
`sudo echo...` won't work for redirecting the output, so write to a temp file, then copy across with sudo.