### PR TITLE
Fixes for raspbian lite around wifi-to-eth-route.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Without desktop (lite version), edit `/etc/rc.local` with root privilege:
 
 And add the following before `exit 0` to start script automatically after reboot:
 
-    bash /home/pi/wifi-to-eth-route.sh
+    bash /home/pi/wifi-to-eth-route.sh &
 
 Be sure to give full path to the file.<br>
 That's it! Reboot to see the changes.

--- a/wifi-to-eth-route.sh
+++ b/wifi-to-eth-route.sh
@@ -30,6 +30,8 @@ sudo iptables -A FORWARD -i $eth -o $wlan -j ACCEPT
 
 sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
+sudo ifconfig $eth down
+sudo ifconfig $eth up
 sudo ifconfig $eth $ip_address netmask $netmask
 
 # Remove default route created by dhcpcd


### PR DESCRIPTION
- fix correct execution at boot
- fix ability to run even if ethernet cable is already plugged in