### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ If you want to make your raspberry pi a router or something than you won't have 
 
 ## How to use them
 
-First, install `dnsmasq` because it the backbone of most of the recipes.
+First, install `dnsmasq` and `iptables` because they are needed for most of the recipes.
 
-    sudo apt-get update && sudo apt-get install dnsmasq
+    sudo apt-get update && sudo apt-get install dnsmasq iptables
 
 List of all recipes with descriptions:
 


### PR DESCRIPTION
Iptables is needed, found this when manually running wifi to eth on RPiOS Bullseye, errors from the OS say iptables isn't found.