### PR TITLE
Fix #63

### DIFF
--- a/wifi-to-eth-route.sh
+++ b/wifi-to-eth-route.sh
@@ -42,7 +42,7 @@ sudo systemctl stop dnsmasq
 
 sudo rm -rf /etc/dnsmasq.d/* &> /dev/null
 
-echo "interface=$eth
+echo -e "interface=$eth
 bind-interfaces
 server=$dns_server
 domain-needed


### PR DESCRIPTION
When using the wifi-to-eth-route.sh script I noticed that the the
dnsmasq.conf was not working because there were `\n` string literals.

The simple fix is to pass the `-e` flag to the echo command.
Just like in the [other scripts](https://github.com/arpitjindal97/raspbian-recipes/blob/master/wifi-to-wifi-route.sh#L59)

Tested and working on `Raspbian GNU/Linux 11 (bullseye)`

Simple example:
```
pi@raspberrypi:~ $ echo -e "foo\nbar"
foo
bar
pi@raspberrypi:~ $ echo "foo\nbar"
foo\nbar
```